### PR TITLE
Remove unnecessary comments and rename commands

### DIFF
--- a/addons/copper_dc/scripts/built_in_commands.gd
+++ b/addons/copper_dc/scripts/built_in_commands.gd
@@ -19,7 +19,7 @@ func init():
 	
 	# Show log
 	DebugConsole.add_command_setvar(
-		"show_log", 
+		"show_mini_log", 
 		_show_log, 
 		self, 
 		DebugCommand.ParameterType.Bool,
@@ -43,9 +43,9 @@ func init():
 	)
 	
 	var monitors = DebugConsole.get_console().monitors.keys()
-	# Show monitor
+	# Show/hide monitor
 	DebugConsole.add_command(
-		"show_monitor",
+		"set_monitor_visible",
 		DebugConsole.set_monitor_visible,
 		DebugConsole,
 		[
@@ -53,7 +53,6 @@ func init():
 			DebugCommand.Parameter.new("visible", DebugCommand.ParameterType.Bool)
 		]
 	)
-	# Hide monitor
 
 func list_files_in_directory(path):
 	var files = []
@@ -95,7 +94,6 @@ func _exec(file):
 	var commandCount = 0
 	for command in commands:
 		if command.replace(" ", "") != "":
-			#DebugConsole.log("> " + command)
 			DebugConsole.get_console().process_command(command)
 			commandCount += 1
 	DebugConsole.log("File " + file + ".cfg ran " + str(commandCount) + " commands.")

--- a/addons/copper_dc/scripts/debug_console.gd
+++ b/addons/copper_dc/scripts/debug_console.gd
@@ -198,7 +198,6 @@ func _get_parameter_text(command, currentParameter=-1) -> String:
 		else:
 			text += " <" + parameter.name + ": " + DebugCommand.ParameterType.keys()[parameter.type] + ">"
 		if command.getFunction != null:
-			#print(typeof(command.getFunction))
 			var value = command.getFunction.call()
 			if value != null:
 				text += " === " + str(value)
@@ -407,11 +406,6 @@ static func show_console():
 	console.consolePanel.visible = true
 	console.stats.visible = true
 	console.miniLog.visible = false
-	#for child in get_console().get_children():
-		#if child.name != "Mini Log":
-			#child.visible = true
-		#else:
-			#child.visible = false
 	
 	if console.pauseOnOpen: console.get_tree().paused = true
 


### PR DESCRIPTION
Removed various bits of commented out code. Also renamed `show_monitor` to `set_monitor_visible` and `show_log` to `show_mini_log` to be a bit more descriptive.