### PR TITLE
Add `help` command

### DIFF
--- a/addons/copper_dc/debug_console.tscn
+++ b/addons/copper_dc/debug_console.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://dbrhac66svoau"]
+[gd_scene load_steps=2 format=3 uid="uid://bcs4bvx7fi2hm"]
 
 [ext_resource type="Script" path="res://addons/copper_dc/scripts/debug_console.gd" id="1_fs6bc"]
 

--- a/addons/copper_dc/scripts/built_in_commands.gd
+++ b/addons/copper_dc/scripts/built_in_commands.gd
@@ -5,7 +5,9 @@ func init():
 	DebugConsole.add_command(
 		"clear", 
 		DebugConsole.clear_log, 
-		DebugConsole
+		DebugConsole,
+		[],
+		"Clears the console."
 	)
 	
 	# Show stats
@@ -13,7 +15,8 @@ func init():
 		"show_stats", 
 		_show_stats, 
 		self, 
-		DebugCommand.ParameterType.Bool, 
+		DebugCommand.ParameterType.Bool,
+		"Sets whether the stats in the top left is visible.",
 		_get_stats_shown
 	)
 	
@@ -23,6 +26,7 @@ func init():
 		_show_log, 
 		self, 
 		DebugCommand.ParameterType.Bool,
+		"Sets whether the mini log in the top right is visible.",
 		_get_log_shown
 	)
 	
@@ -39,14 +43,17 @@ func init():
 		"exec", 
 		_exec, 
 		self, 
-		[DebugCommand.Parameter.new("cfg", DebugCommand.ParameterType.Options, cfgs)]
+		[DebugCommand.Parameter.new("cfg", DebugCommand.ParameterType.Options, cfgs)],
+		"Executes the given cfg file, from top to bottom."
 	)
 	
 	# Open cfg directory
 	DebugConsole.add_command(
 		"open_cfg_dir", 
 		_open_cfg_dir, 
-		self
+		self,
+		[],
+		"Opens the directory where cfg files are can be put to execute. If the directory does not exist, it will be created."
 	)
 	
 	var monitors = DebugConsole.get_console().monitors.keys()
@@ -58,7 +65,19 @@ func init():
 		[
 			DebugCommand.Parameter.new("monitor", DebugCommand.ParameterType.Options, monitors),
 			DebugCommand.Parameter.new("visible", DebugCommand.ParameterType.Bool)
-		]
+		],
+		"Sets whether a particular stat monitor is visible."
+	)
+	
+	var commands = DebugConsole.get_console().commands.keys()
+	commands.sort()
+	# Help
+	DebugConsole.add_command(
+		"help",
+		_help,
+		self,
+		[DebugCommand.Parameter.new("command", DebugCommand.ParameterType.Options, commands)],
+		"Use to get help on any particular command."
 	)
 
 func list_files_in_directory(path):
@@ -107,3 +126,7 @@ func _exec(file):
 
 func _open_cfg_dir():
 	OS.shell_open(ProjectSettings.globalize_path("user://cfg"))
+
+func _help(command):
+	var helpText = DebugConsole.get_console().commands[command].helpText
+	DebugConsole.log(command + " - " + (helpText if helpText != "" else "There is no help available."))

--- a/addons/copper_dc/scripts/debug_command.gd
+++ b/addons/copper_dc/scripts/debug_command.gd
@@ -4,13 +4,15 @@ var id: String
 var parameters: Array
 var function: Callable
 var functionInstance: Object
+var helpText: String
 var getFunction
 
-func _init(id:String, function:Callable, functionInstance: Object, parameters:Array=[], getFunction=null):
+func _init(id:String, function:Callable, functionInstance: Object, parameters:Array=[], helpText:String="", getFunction=null):
 	self.id = id
 	self.parameters = parameters
 	self.function = function
 	self.functionInstance = functionInstance
+	self.helpText = helpText
 	if getFunction != null: self.getFunction = getFunction
 
 class Parameter:

--- a/addons/copper_dc/scripts/debug_console.gd
+++ b/addons/copper_dc/scripts/debug_console.gd
@@ -338,13 +338,13 @@ static func clear_log():
 #endregion
 
 #region Creating commands
-static func add_command(id:String, function:Callable, functionInstance:Object, parameters:Array=[], getFunction=null):
-	get_console().commands[id] = DebugCommand.new(id, function, functionInstance, parameters, getFunction)
+static func add_command(id:String, function:Callable, functionInstance:Object, parameters:Array=[], helpText:String="", getFunction=null):
+	get_console().commands[id] = DebugCommand.new(id, function, functionInstance, parameters, helpText, getFunction)
 
-static func add_command_setvar(id:String, function:Callable, functionInstance:Object, type:DebugCommand.ParameterType, getFunction=null):
+static func add_command_setvar(id:String, function:Callable, functionInstance:Object, type:DebugCommand.ParameterType, helpText:String="", getFunction=null):
 	get_console().commands[id] = DebugCommand.new(id, function, functionInstance, [
 		DebugCommand.Parameter.new("value", type)
-	], getFunction)
+	], helpText, getFunction)
 
 static func add_command_obj(command:DebugCommand):
 	get_console().commands[command.id] = command


### PR DESCRIPTION
Adds the `help` command, along with help texts for all built-in commands. Note that this one could cause errors upon updating since the `helpText` parameter comes before the `getFunction` parameter since the `helpText` is used more. All you need to add is some empty quotes before the get function.