### PR TITLE
Allow on/off and 0/1 in addition to true/false

### DIFF
--- a/addons/copper_dc/scripts/debug_console.gd
+++ b/addons/copper_dc/scripts/debug_console.gd
@@ -279,9 +279,11 @@ func process_command(command):
 		# Bool parameter
 		elif currentParameterObj.type == DebugCommand.ParameterType.Bool:
 			var value = commandSplit[i].to_lower()
-			if value != "true" and value != "false":
-				DebugConsole.log_error("Parameter " + currentParameterObj.name + " should be an bool, but an incorrect value was passed.")
+			var options = {true: ["true", "on", "1"], false: ["false", "off", "0"]}
+			if value not in options[true] and value not in options[false]:
+				DebugConsole.log_error("Parameter " + currentParameterObj.name + " should be a bool, but an incorrect value was passed.")
 				return
+			value = "true" if value in options[true] else "false"
 			commandFunction += value + ","
 			currentParameter += 1
 		# Options parameter


### PR DESCRIPTION
This way, if the user forgets momentarily and falls back on C habits (1/0) or settings habits (on/off) it still works.

Fixes #13.