### PR TITLE
Fix errors when keybinds are missing

### DIFF
--- a/addons/copper_dc/scripts/debug_console.gd
+++ b/addons/copper_dc/scripts/debug_console.gd
@@ -87,15 +87,18 @@ func _process(delta):
 				stats.text += monitor.displayName + ": " + monitor.value + "\n"
 
 func _input(event):
+	var open_debug_pressed = event.is_action_pressed("open_debug") if InputMap.has_action("open_debug") else false
+	var toggle_debug_pressed = event.is_action_pressed("toggle_debug") if InputMap.has_action("toggle_debug") else false
+	
 	# Open debug
-	if !consolePanel.visible and (event.is_action_pressed("open_debug") or (event.is_action_pressed("toggle_debug") if event.is_action("toggle_debug") else false)):
+	if !consolePanel.visible and (open_debug_pressed or toggle_debug_pressed):
 		show_console()
 		_on_command_field_text_changed(commandField.text)
 		# This is stupid but it works
 		await get_tree().create_timer(0.02).timeout
 		commandField.grab_focus()
 	# Close debug
-	elif consolePanel.visible and (event.is_action_pressed("ui_cancel") or (event.is_action_pressed("toggle_debug") if event.is_action("toggle_debug") else false)):
+	elif consolePanel.visible and (event.is_action_pressed("ui_cancel") or toggle_debug_pressed):
 		hide_console(showStats, showMiniLog)
 	# Enter command
 	elif consolePanel.visible and event.is_action_pressed("ui_text_submit"):


### PR DESCRIPTION
Stops errors from happening when there is no `open_debug` or `toggle_debug` keybind in the InputMap.

Apparently I left a non-functional fix for this in the last commit so ignore that.